### PR TITLE
(LYR-167) Add recursive type registration to ServiceBuilder

### DIFF
--- a/annotation/issues.go
+++ b/annotation/issues.go
@@ -4,8 +4,9 @@ import "github.com/lyraproj/issue/issue"
 
 const (
 	RA_ANNOTATED_IS_NOT_OBJECT         = `RA_ANNOTATED_IS_NOT_OBJECT`
+	RA_ATTRIBUTE_NOT_FOUND             = `RA_ATTRIBUTE_NOT_FOUND`
 	RA_PROVIDED_ATTRIBUTE_IS_REQUIRED  = `RA_PROVIDED_ATTRIBUTE_IS_REQUIRED`
-	RA_PROVIDED_ATTRIBUTE_NOT_FOUND    = `RA_PROVIDED_ATTRIBUTE_NOT_FOUND`
+	RA_RELATIONSHIP_KEYS_UNEVEN_NUMBER = `RA_RELATIONSHIP_KEYS_UNEVEN_NUMBER`
 	RA_RELATIONSHIP_TYPE_IS_NOT_OBJECT = `RA_RELATIONSHIP_TYPE_IS_NOT_OBJECT`
 	RA_NO_RESOURCE_ANNOTATION          = `RA_NO_RESOURCE_ANNOTATION`
 	RA_MULTIPLE_COUNTERPARTS           = `RA_MULTIPLE_COUNTERPARTS`
@@ -15,8 +16,9 @@ const (
 
 func init() {
 	issue.Hard2(RA_ANNOTATED_IS_NOT_OBJECT, `annotated %{type} is not an Object`, issue.HF{`attr`: issue.Label})
+	issue.Hard2(RA_ATTRIBUTE_NOT_FOUND, `%{type} has no attribute named %{name}`, issue.HF{`type`: issue.Label})
 	issue.Hard2(RA_PROVIDED_ATTRIBUTE_IS_REQUIRED, `provided attribute %{attr} cannot be required`, issue.HF{`attr`: issue.Label})
-	issue.Hard2(RA_PROVIDED_ATTRIBUTE_NOT_FOUND, `%{type} has no attribute named %{name}`, issue.HF{`type`: issue.Label})
+	issue.Hard2(RA_RELATIONSHIP_KEYS_UNEVEN_NUMBER, `relationship type %{type} has an uneven number of keys`, issue.HF{`type`: issue.Label})
 	issue.Hard2(RA_RELATIONSHIP_TYPE_IS_NOT_OBJECT, `relationship type %{type} is not an Object`, issue.HF{`type`: issue.Label})
 	issue.Hard2(RA_NO_RESOURCE_ANNOTATION, `relationship type %{type} has no Resource annotation`, issue.HF{`type`: issue.Label})
 	issue.Hard2(RA_MULTIPLE_COUNTERPARTS, `relationship type %{type} has multiple matching counterparts for relation %{name}`, issue.HF{`type`: issue.Label})

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,12 @@ module github.com/lyraproj/servicesdk
 
 require (
 	github.com/golang/protobuf v1.2.0
-	github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f
+	github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc
-	github.com/lyraproj/puppet-evaluator v0.0.0-20190108174012-d1a11f151189
+	github.com/lyraproj/puppet-evaluator v0.0.0-20190110164640-b6d2f2955bc2
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
-	golang.org/x/net v0.0.0-20190108155000-395948e2f546
+	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 	google.golang.org/grpc v1.17.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc
-	github.com/lyraproj/puppet-evaluator v0.0.0-20190110164640-b6d2f2955bc2
+	github.com/lyraproj/puppet-evaluator v0.0.0-20190113112749-c332505e3b49
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 	google.golang.org/grpc v1.17.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,10 @@ github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:o
 github.com/lyraproj/issue v0.0.0-20181204205859-7ed1f9741f4a/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc h1:OD9e7aHLSyJcrwG1R/8JsDVIWevC7aJH+Yd09q/8e2I=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190110164640-b6d2f2955bc2 h1:/nchedVJFBHq/5u/HqiOwoiA66N7UyELtgMv4t6y4NI=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190110164640-b6d2f2955bc2/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190111150341-5d0f54630eaa h1:q/HR/CUO6evRAwfgwgTdqu9K5EoLMDmG92GTmY7sH4c=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190111150341-5d0f54630eaa/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190113112749-c332505e3b49 h1:/LvT3MC1eyFqR6p/oO2WqKx8KhN7sq9I+her4ubRWZ4=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190113112749-c332505e3b49/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
-github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f h1:Yv9YzBlAETjy6AOX9eLBZ3nshNVRREgerT/3nvxlGho=
-github.com/hashicorp/go-hclog v0.0.0-20181001195459-61d530d6c27f/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e h1:SS6R03q1M5bxjbOL2JziQUUu7opiRocL4R2H5Y2I6rY=
+github.com/hashicorp/go-hclog v0.0.0-20190109152822-4783caec6f2e/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a h1:z9eTtDWoxYrJvtAD+xAepmTEfEmYgouWUytJ84UWAr8=
 github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a/go.mod h1:Ft7ju2vWzhO0ETMKUVo12XmXmII6eSUS4rsPTkY/siA=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
@@ -18,10 +18,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:o
 github.com/lyraproj/issue v0.0.0-20181204205859-7ed1f9741f4a/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc h1:OD9e7aHLSyJcrwG1R/8JsDVIWevC7aJH+Yd09q/8e2I=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190104213806-d43b938481a5 h1:HrZMm1Xb738Iy6XBXFBqZK2WLpBU2oLklQ2/c7TJCPI=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190104213806-d43b938481a5/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190108174012-d1a11f151189 h1:kzLhELyOd9BiSfVQ5DBhEoQWCvosNmwgQ2L7KzWPmN0=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190108174012-d1a11f151189/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190110164640-b6d2f2955bc2 h1:/nchedVJFBHq/5u/HqiOwoiA66N7UyELtgMv4t6y4NI=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190110164640-b6d2f2955bc2/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
@@ -34,10 +32,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190108155000-395948e2f546 h1:tkMg6+6TF2qZ/3I8fw+DiNgPSsABxdVIqWE90w8Vxzk=
-golang.org/x/net v0.0.0-20190108155000-395948e2f546/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/service/definition.go
+++ b/service/definition.go
@@ -8,10 +8,8 @@ import (
 	"io"
 )
 
-var Definition_Type eval.Type
-
 func init() {
-	Definition_Type = eval.NewObjectType(`Service::Definition`, `{
+	serviceapi.Definition_Type = eval.NewObjectType(`Service::Definition`, `{
     attributes => {
       identifier => TypedName,
       serviceId => TypedName,
@@ -99,5 +97,5 @@ func (d *definition) ToString(bld io.Writer, format eval.FormatContext, g eval.R
 }
 
 func (d *definition) PType() eval.Type {
-	return Definition_Type
+	return serviceapi.Definition_Type
 }

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -170,6 +170,8 @@ func ExampleServer_TypeSet_annotated() {
 		sb.RegisterTypes("My",
 			sb.BuildResource(&OwnerRes{}, func(rtb service.ResourceTypeBuilder) {
 				rtb.ProvidedAttributes(`id`)
+				rtb.ImmutableAttributes(`telephone_number`)
+				rtb.Tags(map[string]string{`Phone`: `name=>telephone_number`})
 				rtb.AddRelationship(`mine`, `My::ContainedRes`, annotation.KindContained, annotation.CardinalityMany, ``, []string{`id`, `owner_id`})
 			}),
 			sb.BuildResource(&ContainedRes{}, func(rtb service.ResourceTypeBuilder) {
@@ -226,6 +228,7 @@ func ExampleServer_TypeSet_annotated() {
 	//     OwnerRes => {
 	//       annotations => {
 	//         Lyra::Resource => {
+	//           'immutable_attributes' => ['telephone_number'],
 	//           'provided_attributes' => ['id'],
 	//           'relationships' => {
 	//             'mine' => {
@@ -242,7 +245,7 @@ func ExampleServer_TypeSet_annotated() {
 	//           'type' => Optional[String],
 	//           'value' => undef
 	//         },
-	//         'phone' => String
+	//         'telephone_number' => String
 	//       }
 	//     }
 	//   }

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -89,6 +89,88 @@ func ExampleServer_Metadata_typeSet() {
 	// }]
 }
 
+type MyOuterRes struct {
+	Who  *MyRes
+	What string
+}
+
+func ExampleServer_Nested_type() {
+	eval.Puppet.Do(func(c eval.Context) {
+		sb := service.NewServerBuilder(c, `My::Service`)
+
+		sb.RegisterTypes("My", &MyOuterRes{})
+
+		s := sb.Server()
+		ts, _ := s.Metadata(c)
+		ts.ToString(os.Stdout, eval.PRETTY_EXPANDED, nil)
+		fmt.Println()
+	})
+
+	// Output:
+	// TypeSet[{
+	//   pcore_uri => 'http://puppet.com/2016.1/pcore',
+	//   pcore_version => '1.0.0',
+	//   name_authority => 'http://puppet.com/2016.1/runtime',
+	//   name => 'My',
+	//   version => '0.1.0',
+	//   types => {
+	//     MyOuterRes => {
+	//       attributes => {
+	//         'who' => MyRes,
+	//         'what' => String
+	//       }
+	//     },
+	//     MyRes => {
+	//       attributes => {
+	//         'name' => String,
+	//         'phone' => String
+	//       }
+	//     }
+	//   }
+	// }]
+}
+
+type Person struct {
+	Who      *MyRes
+	Children []*Person
+}
+
+func ExampleServer_Recursive_type() {
+	eval.Puppet.Do(func(c eval.Context) {
+		sb := service.NewServerBuilder(c, `My::Service`)
+
+		sb.RegisterTypes("My", &Person{})
+
+		s := sb.Server()
+		ts, _ := s.Metadata(c)
+		ts.ToString(os.Stdout, eval.PRETTY_EXPANDED, nil)
+		fmt.Println()
+	})
+
+	// Output:
+	// TypeSet[{
+	//   pcore_uri => 'http://puppet.com/2016.1/pcore',
+	//   pcore_version => '1.0.0',
+	//   name_authority => 'http://puppet.com/2016.1/runtime',
+	//   name => 'My',
+	//   version => '0.1.0',
+	//   types => {
+	//     MyRes => {
+	//       attributes => {
+	//         'name' => String,
+	//         'phone' => String
+	//       }
+	//     },
+	//     Person => {
+	//       attributes => {
+	//         'who' => MyRes,
+	//         'children' => Array[Person]
+	//       }
+	//     }
+	//   }
+	// }]
+}
+
 func ExampleServer_Metadata_definitions() {
 	eval.Puppet.Do(func(c eval.Context) {
 		sb := service.NewServerBuilder(c, `My::Service`)

--- a/service/serverbuilder.go
+++ b/service/serverbuilder.go
@@ -175,7 +175,32 @@ func (ds *ServerBuilder) registerReflectedType(namespace string, tg eval.Annotat
 		return et
 	}
 
-	et = ds.ctx.Reflector().TypeFromTagged(name, pt, tg)
+	et = ds.ctx.Reflector().TypeFromTagged(name, pt, tg, func() {
+		// Register nested types unless already known to the implementation registry
+		nf := typ.NumField()
+		ir := ds.ctx.ImplementationRegistry()
+		for i := 0; i < nf; i++ {
+			f := typ.Field(i)
+			if f.PkgPath != `` {
+				// Unexported
+				continue
+			}
+
+			ft := f.Type
+			switch ft.Kind() {
+			case reflect.Slice, reflect.Interface, reflect.Ptr, reflect.Array:
+				ft = ft.Elem()
+			}
+
+			if ft == parent || ft.Kind() != reflect.Struct {
+				continue
+			}
+
+			if _, ok := ir.ReflectedToType(ft); !ok {
+				ds.registerReflectedType(namespace, eval.NewAnnotatedType(ft, nil, nil))
+			}
+		}
+	})
 	ds.types[name] = et
 	return et
 }

--- a/serviceapi/definition.go
+++ b/serviceapi/definition.go
@@ -1,9 +1,11 @@
 package serviceapi
 
 import (
-	"github.com/lyraproj/puppet-evaluator/eval"
 	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/puppet-evaluator/eval"
 )
+
+var Definition_Type eval.Type
 
 type Definition interface {
 	eval.Value


### PR DESCRIPTION
This commit changes the ServiceBuilder.RegisterType so that it
recursively registers struct types as they are encountered in fields of
the type that are currently being registered.