### PR TITLE
(LYR-168) Do not register type of registered state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc
-	github.com/lyraproj/puppet-evaluator v0.0.0-20190114104021-a0233aa3f992
+	github.com/lyraproj/puppet-evaluator v0.0.0-20190116142411-2aee65d8f315
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
-	google.golang.org/grpc v1.17.0
+	google.golang.org/grpc v1.18.0
 )

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:o
 github.com/lyraproj/issue v0.0.0-20181204205859-7ed1f9741f4a/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc h1:OD9e7aHLSyJcrwG1R/8JsDVIWevC7aJH+Yd09q/8e2I=
 github.com/lyraproj/issue v0.0.0-20181208172701-8d203563a8dc/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190114104021-a0233aa3f992 h1:6f6YlBg5p7Jtu6zlDMe322zksOFfvhU/zjnG5zeyKgs=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190114104021-a0233aa3f992/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190116142411-2aee65d8f315 h1:9hDSL34CwwoYhLpCL/hXXAtGBK/gxFiaxbeLxRV0Dyk=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190116142411-2aee65d8f315/go.mod h1:zzujLCRGe29CXjx2PYphNjYQAnasgzsz+np2ww6d3Mo=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
@@ -45,6 +45,6 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
-google.golang.org/grpc v1.17.0 h1:TRJYBgMclJvGYn2rIMjj+h9KtMt5r1Ij7ODVRIZkwhk=
-google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
+google.golang.org/grpc v1.18.0 h1:IZl7mfBGfbhYx2p2rKRtYgDFw6SBz+kclmxYrCksPPA=
+google.golang.org/grpc v1.18.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/service/serverbuilder.go
+++ b/service/serverbuilder.go
@@ -107,10 +107,6 @@ func (ds *ServerBuilder) RegisterApiType(name string, callable interface{}) {
 
 // RegisterState registers the unresolved state of a resource.
 func (ds *ServerBuilder) RegisterState(name string, state wfapi.State) {
-	t := state.Type()
-	if _, ok := ds.types[t.Name()]; !ok {
-		ds.RegisterType(t)
-	}
 	ds.states[name] = state
 }
 
@@ -387,8 +383,11 @@ func addName(ks []string, tree map[string]interface{}, t eval.Type) {
 }
 
 func (ds *ServerBuilder) Server() *Server {
-	ts := CreateTypeSet(ds.types)
-	ds.ctx.AddTypes(ts)
+	var ts eval.TypeSet
+	if len(ds.types) > 0 {
+		ts = CreateTypeSet(ds.types)
+		ds.ctx.AddTypes(ts)
+	}
 
 	defs := make([]eval.Value, 0, len(ds.callables)+len(ds.activities))
 


### PR DESCRIPTION
This commit ensures that the type of a registered state isn't registered
to become part of the TypeSet that is generated from the ServiceBuilder.
Instead, it is assumed that all state types must be known in advance.