### PR TITLE
Fix bug causing time.Time to be traversed when registering struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20181212150838-f444068e8f5a
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb
-	github.com/lyraproj/puppet-evaluator v0.0.0-20190124135843-af8c63460165
+	github.com/lyraproj/puppet-evaluator v0.0.0-20190124220224-0b2cf0dd23a8
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e
 	google.golang.org/grpc v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:o
 github.com/lyraproj/issue v0.0.0-20181204205859-7ed1f9741f4a/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb h1:R3ukQUNWJTypfOAZwyJ5kcIyWjbm8KZnpxLaH29HWbw=
 github.com/lyraproj/issue v0.0.0-20190122215520-5efbea1d1edb/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190124135843-af8c63460165 h1:LypP0Q6qrh0TkscpeYFpJYxUsFVCqZsbQ6l0Cr3a3Mg=
-github.com/lyraproj/puppet-evaluator v0.0.0-20190124135843-af8c63460165/go.mod h1:Z0RDGXCJwnba8AZttdopo2/JzUiGsN7CECdUqZPR3wU=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190124220224-0b2cf0dd23a8 h1:Oo+0o/N6h29OvBrOZfnrQyVzw2CTNC/dAz3TVtA97kM=
+github.com/lyraproj/puppet-evaluator v0.0.0-20190124220224-0b2cf0dd23a8/go.mod h1:Z0RDGXCJwnba8AZttdopo2/JzUiGsN7CECdUqZPR3wU=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d h1:iDn6XlJAiA+BuwG6L8xsCapPpc7jz24SGj9z7NQA1sg=
 github.com/lyraproj/puppet-parser v0.0.0-20181212205830-31c3104fe78d/go.mod h1:8va5g/XEw+jP9jnwEXPmanUy/hD9+6iggnaioihPLP0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lyraproj/servicesdk/service"
 	"github.com/lyraproj/servicesdk/wfapi"
 	"os"
+	"time"
 
 	// Initialize pcore
 	_ "github.com/lyraproj/puppet-evaluator/pcore"
@@ -136,6 +137,7 @@ func ExampleServer_Nested_type() {
 type Person struct {
 	Who      *MyRes
 	Children []*Person
+	Born     time.Time
 }
 
 func ExampleServer_Recursive_type() {
@@ -170,7 +172,8 @@ func ExampleServer_Recursive_type() {
 	//           'type' => Optional[MyRes],
 	//           'value' => undef
 	//         },
-	//         'children' => Array[Optional[Person]]
+	//         'children' => Array[Optional[Person]],
+	//         'born' => Timestamp
 	//       }
 	//     }
 	//   }

--- a/service/serverbuilder.go
+++ b/service/serverbuilder.go
@@ -171,8 +171,6 @@ func (ds *ServerBuilder) registerReflectedType(namespace string, tg eval.Annotat
 		return et
 	}
 
-	ir := ds.ctx.ImplementationRegistry()
-
 	var registerFieldType func(ft reflect.Type)
 	registerFieldType = func(ft reflect.Type) {
 		switch ft.Kind() {
@@ -182,11 +180,10 @@ func (ds *ServerBuilder) registerReflectedType(namespace string, tg eval.Annotat
 			if ft == parent {
 				break
 			}
-			if _, ok := ir.ReflectedToType(ft); ok {
-				// Already registered
-				break
+			// Register type unless it's already registered
+			if _, err := eval.WrapReflectedType(ds.ctx, ft); err != nil {
+				ds.registerReflectedType(namespace, eval.NewAnnotatedType(ft, nil, nil))
 			}
-			ds.registerReflectedType(namespace, eval.NewAnnotatedType(ft, nil, nil))
 		}
 	}
 


### PR DESCRIPTION
This commit ensures that no well-known structs are traversed when using
the ServiceBuilder.RegisterType() to register a struct and all types
that it contains.