### PR TITLE
Ensure that the callable's API origins from the ImplementationRegistry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20190319145359-029b4266d45b
-	github.com/lyraproj/pcore v0.0.0-20190319163905-c435c6e1b96e
+	github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	google.golang.org/grpc v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/lyraproj/pcore v0.0.0-20190317133239-e367a175e431/go.mod h1:hKQkpsnpe
 github.com/lyraproj/pcore v0.0.0-20190319142435-27ce0d28a7c5 h1:XTHjvfLXrF73FG9nTiJC4ej/W0wk6ZCDpS8WMSXejdo=
 github.com/lyraproj/pcore v0.0.0-20190319163905-c435c6e1b96e h1:W2omAJqkyi++wiadcWBNKTyBnlLJ8p2WXYFTMu5AsMo=
 github.com/lyraproj/pcore v0.0.0-20190319163905-c435c6e1b96e/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
+github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d h1:ys6G0Z5Ckm5q+UD8EEQy3Qjpz8d+KkFawd3oF3PwrcE=
+github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/lang/typegen/puppet_test.go
+++ b/lang/typegen/puppet_test.go
@@ -75,18 +75,12 @@ func ExampleGenerator_GenerateTypes_puppet() {
 	//       attributes => {
 	//         'name' => String,
 	//         'gender' => Enum['male', 'female', 'other'],
-	//         'address' => {
-	//           'type' => Optional[Address],
-	//           'value' => undef
-	//         }
+	//         'address' => Optional[Address]
 	//       }
 	//     },
 	//     ExtendedPerson => Person{
 	//       attributes => {
-	//         'age' => {
-	//           'type' => Optional[Integer],
-	//           'value' => undef
-	//         },
+	//         'age' => Optional[Integer],
 	//         'enabled' => Boolean
 	//       }
 	//     }

--- a/service/builder.go
+++ b/service/builder.go
@@ -59,8 +59,6 @@ func (ds *Builder) RegisterAPI(name string, callable interface{}) {
 		pt, ok := ds.ctx.ImplementationRegistry().ReflectedToType(rt)
 		if !ok {
 			pt = ds.ctx.Reflector().TypeFromReflect(name, nil, rt)
-		}
-		if _, ok := ds.types[name]; !ok {
 			ds.registerType(name, pt)
 		}
 		ds.registerCallable(name, rv)
@@ -390,9 +388,12 @@ func (ds *Builder) Server() *Server {
 
 	callableStyle := types.WrapString(`callable`)
 	// Create invokable definitions for callables
-	for k := range ds.callables {
+	for k, v := range ds.callables {
 		props := make([]*types.HashEntry, 0, 2)
-		props = append(props, types.WrapHashEntry2(`interface`, ds.types[k]))
+		if pt, ok := ds.ctx.ImplementationRegistry().ReflectedToType(v.Type()); ok {
+			props = append(props, types.WrapHashEntry2(`interface`, pt))
+		}
+
 		props = append(props, types.WrapHashEntry2(`style`, callableStyle))
 		if stateType, ok := ds.handlerFor[k]; ok {
 			props = append(props, types.WrapHashEntry2(`handlerFor`, stateType))

--- a/service/builder.go
+++ b/service/builder.go
@@ -56,9 +56,9 @@ func (ds *Builder) RegisterAPI(name string, callable interface{}) {
 	} else {
 		rv := reflect.ValueOf(callable)
 		rt := rv.Type()
-		pt, ok := ds.ctx.ImplementationRegistry().ReflectedToType(rt)
+		_, ok := ds.ctx.ImplementationRegistry().ReflectedToType(rt)
 		if !ok {
-			pt = ds.ctx.Reflector().TypeFromReflect(name, nil, rt)
+			pt := ds.ctx.Reflector().TypeFromReflect(name, nil, rt)
 			ds.registerType(name, pt)
 		}
 		ds.registerCallable(name, rv)

--- a/service/definition.go
+++ b/service/definition.go
@@ -73,7 +73,7 @@ func (d *definition) InitHash() px.OrderedMap {
 
 func (d *definition) Equals(other interface{}, g px.Guard) bool {
 	if o, ok := other.(*definition); ok {
-		return d.identifier == o.identifier && d.serviceId.Equals(o.serviceId, g) && d.properties.Equals(o.properties, g)
+		return d.identifier.Equals(o.identifier, g) && d.serviceId.Equals(o.serviceId, g) && d.properties.Equals(o.properties, g)
 	}
 	return false
 }

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -115,10 +115,7 @@ func ExampleBuilder_RegisterTypes_nestedType() {
 	//   types => {
 	//     MyOuterRes => {
 	//       attributes => {
-	//         'who' => {
-	//           'type' => Optional[MyRes],
-	//           'value' => undef
-	//         },
+	//         'who' => Optional[MyRes],
 	//         'what' => String
 	//       }
 	//     },
@@ -166,10 +163,7 @@ func ExampleBuilder_RegisterTypes_recursiveType() {
 	//     },
 	//     Person => {
 	//       attributes => {
-	//         'who' => {
-	//           'type' => Optional[MyRes],
-	//           'value' => undef
-	//         },
+	//         'who' => Optional[MyRes],
 	//         'children' => Array[Optional[Person]],
 	//         'born' => Timestamp
 	//       }
@@ -306,10 +300,7 @@ func ExampleBuilder_RegisterTypes_annotatedTypeSet() {
 	//         }
 	//       },
 	//       attributes => {
-	//         'id' => {
-	//           'type' => Optional[String],
-	//           'value' => undef
-	//         },
+	//         'id' => Optional[String],
 	//         'ownerId' => String,
 	//         'stuff' => String
 	//       }
@@ -330,10 +321,7 @@ func ExampleBuilder_RegisterTypes_annotatedTypeSet() {
 	//         }
 	//       },
 	//       attributes => {
-	//         'id' => {
-	//           'type' => Optional[String],
-	//           'value' => undef
-	//         },
+	//         'id' => Optional[String],
 	//         'telephoneNumber' => String
 	//       }
 	//     }


### PR DESCRIPTION
When many callables share the same API, the name of the callable will
not match its type. Instead the type must be retrieved from the
ImplementationRegistry.