### PR TITLE
Improve TypeScript generator to generate interfaces for anonymous types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/lyraproj/issue v0.0.0-20190319145359-029b4266d45b
 	github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	google.golang.org/grpc v1.19.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20190319145359-029b4266d45b
-	github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d
+	github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	google.golang.org/grpc v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
 	github.com/lyraproj/issue v0.0.0-20190319145359-029b4266d45b
-	github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315
+	github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/lyraproj/pcore v0.0.0-20190319163905-c435c6e1b96e h1:W2omAJqkyi++wiad
 github.com/lyraproj/pcore v0.0.0-20190319163905-c435c6e1b96e/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d h1:ys6G0Z5Ckm5q+UD8EEQy3Qjpz8d+KkFawd3oF3PwrcE=
 github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
+github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315 h1:GWlFZY4ckasl1OPK4x1Fn86ug1clSD1XN3hu26JqpRA=
+github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -47,9 +48,11 @@ github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d h1:ys6G0Z5Ckm5q+UD8
 github.com/lyraproj/pcore v0.0.0-20190401141000-d68cedf4b03d/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315 h1:GWlFZY4ckasl1OPK4x1Fn86ug1clSD1XN3hu26JqpRA=
 github.com/lyraproj/pcore v0.0.0-20190403083940-12ac86e9d315/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
+github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05 h1:DHDepxY8viIusn1/vd3jrVz6NblNWzIZBAVWeFRUWYk=
+github.com/lyraproj/pcore v0.0.0-20190403155521-a72b635b7c05/go.mod h1:zaYm7Mn2rIKNNpcMGy+QkWUqoTpGAQiAmVwJpJ4wYDc=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/lang/typegen/generator.go
+++ b/lang/typegen/generator.go
@@ -24,7 +24,7 @@ type Generator interface {
 // All known language generators
 var generators = map[string]Generator{
 	"puppet":     &puppetGenerator{},
-	"typescript": &tsGenerator{},
+	"typescript": &tsGeneratorFactory{},
 }
 
 func GetGenerator(language string) Generator {

--- a/lang/typegen/typescript.go
+++ b/lang/typegen/typescript.go
@@ -39,7 +39,7 @@ func (gf *tsGeneratorFactory) GenerateTypes(typeSet px.TypeSet, directory string
 	if len(tts) > 0 {
 		typeToStream(typeSet, directory, `.ts`, func(b io.Writer) {
 			write(b, "// this file is generated\n")
-			write(b, "import {PcoreValue, Value} from 'lyra-workflow';")
+			write(b, "import {PcoreValue, Value} from 'lyra-workflow';\n")
 			g := &tsGenerator{make(map[string]string), strings.Split(typeSet.Name(), `::`), true}
 			for _, t := range tts {
 				g.generateType(t, 0, b)
@@ -52,7 +52,7 @@ func (gf *tsGeneratorFactory) GenerateTypes(typeSet px.TypeSet, directory string
 func (gf *tsGeneratorFactory) GenerateType(typ px.Type, directory string) {
 	typeToStream(typ, directory, `.ts`, func(b io.Writer) {
 		write(b, "// this file is generated\n")
-		write(b, "import {PcoreValue, Value} from 'lyra-workflow';")
+		write(b, "import {PcoreValue, Value} from 'lyra-workflow';\n")
 		g := &tsGenerator{make(map[string]string), namespace(typ.Name()), true}
 		g.generateType(typ, 0, b)
 		g.writeAnonIfds(b)


### PR DESCRIPTION
Since the anonymous types need to be repeated both in the attribute
declaration and in the parameter type declaration, it saves many lines
of codes to instead generate an interface. Here, interfaces are
generated with the name "Anon" followed by a sequence number. The user
will never have to write those names.