### PR TITLE
Change iteration attribute "over" to be a px.Value

### DIFF
--- a/service/builder.go
+++ b/service/builder.go
@@ -259,8 +259,11 @@ func (ds *Builder) createActivityDefinition(activity wf.Activity) serviceapi.Def
 	case wf.Iterator:
 		style = `iterator`
 		props = append(props, types.WrapHashEntry2(`iterationStyle`, types.WrapString(activity.IterationStyle().String())))
-		props = append(props, types.WrapHashEntry2(`over`, paramsAsList(activity.Over())))
-		props = append(props, types.WrapHashEntry2(`variables`, paramsAsList(activity.Variables())))
+		props = append(props, types.WrapHashEntry2(`over`, activity.Over()))
+		vars := activity.Variables()
+		if len(vars) > 0 {
+			props = append(props, types.WrapHashEntry2(`variables`, paramsAsList(vars)))
+		}
 		props = append(props, types.WrapHashEntry2(`producer`, ds.createActivityDefinition(activity.Producer())))
 	}
 	props = append(props, types.WrapHashEntry2(`style`, types.WrapString(style)))

--- a/wf/builder.go
+++ b/wf/builder.go
@@ -50,7 +50,7 @@ type StateHandlerBuilder interface {
 type IteratorBuilder interface {
 	ChildBuilder
 	Style(IterationStyle)
-	Over(...px.Parameter)
+	Over(px.Value)
 	Variables(...px.Parameter)
 }
 
@@ -217,7 +217,7 @@ func (b *childBuilder) AddChild(child Builder) {
 type iteratorBuilder struct {
 	childBuilder
 	style     IterationStyle
-	over      []px.Parameter
+	over      px.Value
 	variables []px.Parameter
 }
 
@@ -258,12 +258,8 @@ func (b *iteratorBuilder) Style(style IterationStyle) {
 	b.style = style
 }
 
-func (b *iteratorBuilder) Over(over ...px.Parameter) {
-	if len(b.over) == 0 {
-		b.over = over
-	} else {
-		b.over = append(b.over, over...)
-	}
+func (b *iteratorBuilder) Over(over px.Value) {
+	b.over = over
 }
 
 func (b *iteratorBuilder) Variables(variables ...px.Parameter) {

--- a/wf/iterator.go
+++ b/wf/iterator.go
@@ -50,9 +50,8 @@ type Iterator interface {
 	// Producer returns the Activity that will be invoked once for each iteration
 	Producer() Activity
 
-	// Over returns what this iterator will iterate over. These parameters will be added
-	// to the declared input set when the final requirements for the activity are computed.
-	Over() []px.Parameter
+	// Over returns what this iterator will iterate over.
+	Over() px.Value
 
 	// Variables returns the variables that this iterator will produce for each iteration. These
 	// variables will be removed from the declared input set when the final requirements
@@ -64,11 +63,11 @@ type iterator struct {
 	activity
 	style     IterationStyle
 	producer  Activity
-	over      []px.Parameter
+	over      px.Value
 	variables []px.Parameter
 }
 
-func MakeIterator(name string, when Condition, input, output []px.Parameter, style IterationStyle, producer Activity, over []px.Parameter, variables []px.Parameter) Iterator {
+func MakeIterator(name string, when Condition, input, output []px.Parameter, style IterationStyle, producer Activity, over px.Value, variables []px.Parameter) Iterator {
 	return &iterator{activity{name, when, input, output}, style, producer, over, variables}
 }
 
@@ -84,7 +83,7 @@ func (it *iterator) Producer() Activity {
 	return it.producer
 }
 
-func (it *iterator) Over() []px.Parameter {
+func (it *iterator) Over() px.Value {
 	return it.over
 }
 


### PR DESCRIPTION
The attribute "over" used to be a px.Parameter which didn't make much
sense since it often should be a plain value such as a number. This
commit changes the attribute to be an arbitrary value.