### PR TITLE
Add special NotFound() function to produce well known error.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b
 	github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995
-	github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569
+	github.com/lyraproj/pcore v0.0.0-20190502085713-c95bdae56d68
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995 h1:vAlBUcYalN98yypS75/zwFciwS6WFYGnizRBJdN320o=
 github.com/lyraproj/issue v0.0.0-20190329160035-8bc10230f995/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569 h1:wzY8l1Rkl5UIwq7/2U56Mi2RkFjzChTTXzAnW311zTE=
-github.com/lyraproj/pcore v0.0.0-20190430133451-57d4da316569/go.mod h1:rEl2ewvqyi/MUo+sEoADKduVlO971HgiLJmu26EO+vM=
+github.com/lyraproj/pcore v0.0.0-20190502085713-c95bdae56d68 h1:/sZhuQeebUbpjuHL9EZCMBn0OJoHrR7okfYD0pnvlTI=
+github.com/lyraproj/pcore v0.0.0-20190502085713-c95bdae56d68/go.mod h1:rEl2ewvqyi/MUo+sEoADKduVlO971HgiLJmu26EO+vM=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/service/issues.go
+++ b/service/issues.go
@@ -10,6 +10,7 @@ const (
 	NoSuchApi            = `WF_NO_SUCH_API`
 	NoSuchMethod         = `WF_NO_SUCH_METHOD`
 	NoSuchState          = `WF_NO_SUCH_STATE`
+	NotFound             = `WF_NOT_FOUND`
 	NotFunc              = `WF_NOT_FUNC`
 	NotPuppetObject      = `WF_NOT_PUPPET_OBJECT`
 	NoStateConverter     = `WF_NO_STATE_CONVERTER`
@@ -25,6 +26,7 @@ func init() {
 	issue.Hard(NoSuchMethod, `the '%{api}' API does not have a method named %{method}`)
 	issue.Hard(NoSuchState, `state '%{name}' not found`)
 	issue.Hard(NoStateConverter, `no state converter has been registered`)
+	issue.Hard(NotFound, `%{typeName} resource with external id '%{extId}' does not exist`)
 	issue.Hard(NotFunc, `attempt to register a function '%{name}' as a %{type}. Expected a func'`)
 	issue.Hard(NotPuppetObject, `expected resource to produce an Object, got '%{actual}'`)
 	issue.Hard(TypeNameClash, `attempt to register '%{goType}' using both '%{oldType}' and '%{newType}'`)

--- a/service/notfound.go
+++ b/service/notfound.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
+)
+
+func init() {
+	serviceapi.NotFound = func(typeName, extId string) error {
+		return px.Error(NotFound, issue.H{`typeName`: typeName, `extId`: extId})
+	}
+}

--- a/serviceapi/error.go
+++ b/serviceapi/error.go
@@ -29,3 +29,7 @@ type ErrorObject interface {
 var ErrorFromReported func(c px.Context, err issue.Reported) ErrorObject
 
 var NewError func(c px.Context, message, kind, issueCode string, partialResult px.Value, details px.OrderedMap) ErrorObject
+
+// NotFound returns the special NotFound error which is recognized by the Lyra workflow engine. It should
+// be used when requests are made to read, update, or delete a resource with an external id that no longer exists.
+var NotFound func(typeName, extId string) error


### PR DESCRIPTION
This commit adds a NotFound() function which returns an error. The
function should be used by providers when a request has been made to
read or update a non existing resource using an external id. This
condition is normally ok and indicates that the identity storage
contains references to resources that no longer exists. By returning
the NotFound error, the workflow engine will be made aware of this and
purge the external ID from the DB.

Relates to lyraproj/lyra#214