### PR TITLE
Only create definitions from APIs that matters to the workflow

### DIFF
--- a/service/server_test.go
+++ b/service/server_test.go
@@ -415,19 +415,5 @@ func ExampleServer_Metadata_api() {
 	//     }
 	//   }
 	// }]
-	// Service::Definition(
-	//   'identifier' => TypedName(
-	//     'namespace' => 'definition',
-	//     'name' => 'My::Identity::Api'
-	//   ),
-	//   'serviceId' => TypedName(
-	//     'namespace' => 'service',
-	//     'name' => 'My::Service'
-	//   ),
-	//   'properties' => {
-	//     'interface' => My::Identity,
-	//     'style' => 'callable'
-	//   }
-	// )
 	//
 }


### PR DESCRIPTION
This commit ensures that only those APIs that matters to the workflow
engine are propagated as Definitions. Other APIs (such as the function
of an Action) should not be propagated since they cause collisions in
the definition namespace.

This replaces an earlier failed attempt to add an '::Api' suffix to
APIs irrelevant to the wf-engine.