### PR TITLE
Improve error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,6 @@ require (
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	google.golang.org/grpc v1.19.0
 )
+
+// remove once lyraproj/issue#7 is merged
+replace github.com/lyraproj/issue => github.com/thallgren/issue v0.0.0-20190512160618-668e97752cb0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thallgren/issue v0.0.0-20190512160618-668e97752cb0 h1:H+BuJ0XY8YO8DHe08H8gdduqFhNfFthb/kW0J+Ocf9U=
+github.com/thallgren/issue v0.0.0-20190512160618-668e97752cb0/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -60,7 +60,10 @@ func (c *Client) Invoke(ctx px.Context, identifier, name string, arguments ...px
 	}
 	result := FromDataPB(ctx, rr)
 	if eo, ok := result.(serviceapi.ErrorObject); ok {
-		panic(px.Error(InvocationError, issue.H{`identifier`: identifier, `name`: name, `code`: eo.IssueCode(), `message`: eo.Message()}))
+		if re, ok := eo.ToReported(); ok {
+			panic(re)
+		}
+		panic(px.Error(InvocationError, issue.H{`identifier`: identifier, `name`: name, `message`: eo.Message()}))
 	}
 	return result
 }

--- a/grpc/issues.go
+++ b/grpc/issues.go
@@ -7,5 +7,5 @@ const (
 )
 
 func init() {
-	issue.Hard(InvocationError, `invocation of %{identifier} %{name} failed: %{code} %{message}`)
+	issue.Hard(InvocationError, `invocation of %{identifier} %{name} failed: %{message}`)
 }

--- a/lang/go/lyra/collect.go
+++ b/lang/go/lyra/collect.go
@@ -42,7 +42,7 @@ type Collect struct {
 	Step Step
 }
 
-func (e *Collect) Resolve(c px.Context, n string) wf.Step {
+func (e *Collect) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
 	var v px.Value
 	var style wf.IterationStyle
 	if e.Times != nil {
@@ -67,7 +67,7 @@ func (e *Collect) Resolve(c px.Context, n string) wf.Step {
 	}
 
 	return wf.MakeIterator(
-		n, wf.Parse(e.When), nil, nil, style, e.Step.Resolve(c, n), v, asParams(c, e.As), issue.FirstToLower(e.Return))
+		n, loc, wf.Parse(e.When), nil, nil, style, e.Step.Resolve(c, n, loc), v, asParams(c, e.As), issue.FirstToLower(e.Return))
 }
 
 // value is like px.Wrap but transforms single element zero element structs into parameters

--- a/lang/go/lyra/reference.go
+++ b/lang/go/lyra/reference.go
@@ -29,7 +29,7 @@ type Reference struct {
 	StepName string
 }
 
-func (r *Reference) Resolve(c px.Context, n string) wf.Step {
+func (r *Reference) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
 	var parameters, returns []px.Parameter
 	if r.Parameters != nil {
 		parameters = paramsFromStruct(c, reflect.TypeOf(r.Parameters), issue.FirstToLower)
@@ -38,5 +38,5 @@ func (r *Reference) Resolve(c px.Context, n string) wf.Step {
 		returns = paramsFromStruct(c, reflect.TypeOf(r.Return), issue.FirstToLower)
 	}
 	return wf.MakeReference(
-		n, wf.Parse(r.When), parameters, returns, r.StepName)
+		n, loc, wf.Parse(r.When), parameters, returns, r.StepName)
 }

--- a/lang/go/lyra/resource.go
+++ b/lang/go/lyra/resource.go
@@ -33,7 +33,7 @@ type Resource struct {
 	State interface{}
 }
 
-func (r *Resource) Resolve(c px.Context, n string) wf.Step {
+func (r *Resource) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
 	fv := reflect.ValueOf(r.State)
 	ft := fv.Type()
 	if ft.Kind() != reflect.Func {
@@ -120,5 +120,8 @@ func (r *Resource) Resolve(c px.Context, n string) wf.Step {
 		parameters = paramsFromStruct(c, ft.In(0), nil)
 	}
 
-	return wf.MakeResource(n, wf.Parse(r.When), parameters, returns, r.ExternalId, newGoState(ot, fv, returnsError))
+	gs := newGoState(ot, fv, returnsError)
+	rs := wf.MakeResource(n, loc, wf.Parse(r.When), parameters, returns, r.ExternalId, gs)
+	gs.resource = rs
+	return rs
 }

--- a/lang/go/lyra/workflow.go
+++ b/lang/go/lyra/workflow.go
@@ -3,6 +3,8 @@ package lyra
 import (
 	"sort"
 
+	"github.com/lyraproj/issue/issue"
+
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/servicesdk/wf"
 )
@@ -25,14 +27,14 @@ type Workflow struct {
 	Steps map[string]Step
 }
 
-func (w *Workflow) Resolve(c px.Context, n string) wf.Step {
+func (w *Workflow) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
 	as := make([]wf.Step, 0, len(w.Steps))
 	for k, a := range w.Steps {
-		as = append(as, a.Resolve(c, n+`::`+k))
+		as = append(as, a.Resolve(c, n+`::`+k, loc))
 	}
 	sort.Slice(as, func(i, j int) bool {
 		return as[i].Name() < as[j].Name()
 	})
 	return wf.MakeWorkflow(
-		n, wf.Parse(w.When), ParametersFromGoStruct(c, w.Parameters), ParametersFromGoStruct(c, w.Return), as)
+		n, loc, wf.Parse(w.When), ParametersFromGoStruct(c, w.Parameters), ParametersFromGoStruct(c, w.Return), as)
 }

--- a/service/builder.go
+++ b/service/builder.go
@@ -279,6 +279,7 @@ func (ds *Builder) createStepDefinition(step wf.Step) serviceapi.Definition {
 		props = append(props, types.WrapHashEntry2(`reference`, types.WrapString(step.Reference())))
 	}
 	props = append(props, types.WrapHashEntry2(`style`, types.WrapString(style)))
+	props = append(props, types.WrapHashEntry2(`origin`, types.WrapString(issue.LocationString(step.Origin()))))
 	return serviceapi.NewDefinition(px.NewTypedName(px.NsDefinition, name), ds.serviceId, types.WrapHash(props))
 }
 

--- a/service/server.go
+++ b/service/server.go
@@ -85,7 +85,7 @@ func (s *Server) Invoke(c px.Context, api, name string, arguments ...px.Value) (
 		if m, ok := iv.PType().(px.TypeWithCallableMembers).Member(name); ok {
 			defer func() {
 				if x := recover(); x != nil {
-					hclog.Default().Error(`Invoke failed`, `error`, x)
+					hclog.Default().Debug(`Invoke failed`, `error`, x)
 					if err, ok := x.(issue.Reported); ok && string(err.Code()) == px.GoFunctionError {
 						result = serviceapi.ErrorFromReported(c, err)
 						return

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/lyraproj/issue/issue"
+
 	"github.com/lyraproj/servicesdk/lang/go/lyra"
 
 	"github.com/lyraproj/pcore/pcore"
@@ -187,7 +189,7 @@ func ExampleServer_Metadata_definitions() {
 						B string
 					}) *MyRes {
 						return &MyRes{Name: `Bob`, Phone: `12345`}
-					}}}}).Resolve(c, `My::Test`))
+					}}}}).Resolve(c, `My::Test`, issue.ParseLocation(`(file: /test/x.go)`)))
 
 		s := sb.Server()
 		_, defs := s.Metadata(c)
@@ -228,10 +230,12 @@ func ExampleServer_Metadata_definitions() {
 	//               'type' => String
 	//             )],
 	//           'resourceType' => My::MyRes,
-	//           'style' => 'resource'
+	//           'style' => 'resource',
+	//           'origin' => '(file: /test/x.go)'
 	//         }
 	//       )],
-	//     'style' => 'workflow'
+	//     'style' => 'workflow',
+	//     'origin' => '(file: /test/x.go)'
 	//   }
 	// )
 	//
@@ -348,7 +352,7 @@ func ExampleServer_Metadata_state() {
 						B string
 					}) *MyRes {
 						return &MyRes{Name: `Bob`, Phone: `12345`}
-					}}}}).Resolve(c, `My::Test`))
+					}}}}).Resolve(c, `My::Test`, issue.ParseLocation(`(file: /test/x.go)`)))
 
 		s := sb.Server()
 		fmt.Println(px.ToPrettyString(s.State(c, `My::Test::X`, px.EmptyMap)))

--- a/serviceapi/error.go
+++ b/serviceapi/error.go
@@ -24,6 +24,12 @@ type ErrorObject interface {
 	// Details returns the optional details. It returns
 	// an empty map when no details exist
 	Details() px.OrderedMap
+
+	// ToReported checks if the IssueCode represents a known issue.Reported code in this executable,
+	// and if so, reconstructs the original error using the code and arguments and returns it and true.
+	//
+	// nil, false is returned if the IssueCode is unknown to the current executable.
+	ToReported() (issue.Reported, bool)
 }
 
 var ErrorFromReported func(c px.Context, err issue.Reported) ErrorObject

--- a/wf/action.go
+++ b/wf/action.go
@@ -1,6 +1,7 @@
 package wf
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
@@ -15,8 +16,8 @@ type action struct {
 	function interface{}
 }
 
-func MakeAction(name string, when Condition, parameters, returns []px.Parameter, function interface{}) Action {
-	return &action{step{name, when, parameters, returns}, function}
+func MakeAction(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, function interface{}) Action {
+	return &action{step{name, origin, when, parameters, returns}, function}
 }
 
 func (s *action) Label() string {

--- a/wf/issues.go
+++ b/wf/issues.go
@@ -3,23 +3,52 @@ package wf
 import "github.com/lyraproj/issue/issue"
 
 const (
-	ConditionSyntaxError   = `WF_CONDITION_SYNTAX_ERROR`
-	ConditionMissingRp     = `WF_CONDITION_MISSING_RP`
-	ConditionInvalidName   = `WF_CONDITION_INVALID_NAME`
-	ConditionUnexpectedEnd = `WF_CONDITION_UNEXPECTED_END`
-	IllegalIterationStyle  = `WF_ILLEGAL_ITERATION_STYLE`
-	IllegalOperation       = `WF_ILLEGAL_OPERATION`
-	StepNoName             = `WF_STEP_NO_NAME`
-	IteratorNotOneStep     = `WF_ITERATOR_NOT_ONE_STEP`
+	ActionExecutionError     = `WF_ACTION_EXECUTION_ERROR`
+	BadParameter             = `WF_BAD_PARAMETER`
+	ConditionSyntaxError     = `WF_CONDITION_SYNTAX_ERROR`
+	ConditionMissingRp       = `WF_CONDITION_MISSING_RP`
+	ConditionInvalidName     = `WF_CONDITION_INVALID_NAME`
+	ConditionUnexpectedEnd   = `WF_CONDITION_UNEXPECTED_END`
+	ElementNotParameter      = `WF_ELEMENT_NOT_PARAMETER`
+	FieldTypeMismatch        = `WF_FIELD_TYPE_MISMATCH`
+	IllegalIterationStyle    = `WF_ILLEGAL_ITERATION_STYLE`
+	IllegalOperation         = `WF_ILLEGAL_OPERATION`
+	InvalidFunction          = `WF_INVALID_FUNCTION`
+	InvalidTypeName          = `WF_INVALID_TYPE_NAME`
+	IteratorNotOneStep       = `WF_ITERATOR_NOT_ONE_STEP`
+	MissingRequiredField     = `WF_MISSING_REQUIRED_FIELD`
+	MissingRequiredFunction  = `WF_MISSING_REQUIRED_FUNCTION`
+	NoDefinition             = `WF_NO_DEFINITION`
+	NoServerBuilderInContext = `WF_NO_SERVER_BUILDER_IN_CONTEXT`
+	NotStep                  = `WF_NOT_STEP`
+	NotStepDefinition        = `WF_NOT_STEP_DEFINITION`
+	StepBuildError           = `WF_STEP_BUILD_ERROR`
+	StepNoName               = `WF_STEP_NO_NAME`
+	StateCreationError       = `WF_STATE_CREATION_ERROR`
 )
 
 func init() {
+	issue.Hard(ActionExecutionError, `error while executing %{step}`)
+	issue.Hard2(BadParameter, `%{step}: element %{name} is not a valid %{parameterType} parameter`, issue.HF{`step`: issue.Label})
 	issue.Hard(ConditionSyntaxError, `syntax error in condition '%{text}' at position %{pos}`)
 	issue.Hard(ConditionMissingRp, `expected right parenthesis in condition '%{text}' at position %{pos}`)
 	issue.Hard(ConditionInvalidName, `invalid name '%{name}' in condition '%{text}' at position %{pos}`)
 	issue.Hard(ConditionUnexpectedEnd, `unexpected end of condition '%{text}' at position %{pos}`)
+	issue.Hard(ElementNotParameter, `expected field %{field} element to be a Parameter, got %{type}`)
+	issue.Hard(FieldTypeMismatch, `expected field %{field} to be a %{expected}, got %{actual}`)
 	issue.Hard(IllegalIterationStyle, `no such iteration style '%{style}'`)
 	issue.Hard(IllegalOperation, `no such operation '%{operation}'`)
-	issue.Hard(StepNoName, `an step must have a name`)
+	issue.Hard(InvalidFunction, `invalid function '%{function}'. Expected one of 'create', 'read', 'update', or 'delete'`)
+	issue.Hard(InvalidTypeName, `invalid type name '%{name}'. A type name must consist of one to many capitalized segments separated with '::'`)
 	issue.Hard(IteratorNotOneStep, `an iterator must have exactly one step`)
+	issue.Hard(MissingRequiredField, `missing required field '%{field}'`)
+	issue.Hard(MissingRequiredFunction, `missing required '%{function}'`)
+	issue.Hard(NoDefinition, `expected step to contain a definition block`)
+	issue.Hard(NoServerBuilderInContext, `no ServerBuilder has been registered with the evaluation context`)
+	issue.Hard2(NotStep, `block may only contain workflow steps. %{actual} is not supported here`,
+		issue.HF{`actual`: issue.UcAnOrA})
+	issue.Hard(NotStepDefinition, `a step definition must be a hash`)
+	issue.Hard(StepBuildError, `error while building %{step}`)
+	issue.Hard(StepNoName, `an step must have a name`)
+	issue.Hard(StateCreationError, `error while creating %{step} state`)
 }

--- a/wf/iterator.go
+++ b/wf/iterator.go
@@ -71,8 +71,9 @@ type iterator struct {
 	into      string
 }
 
-func MakeIterator(name string, when Condition, parameters, returns []px.Parameter, style IterationStyle, producer Step, over px.Value, variables []px.Parameter, into string) Iterator {
-	return &iterator{step{name, when, parameters, returns}, style, producer, over, variables, into}
+func MakeIterator(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter,
+	style IterationStyle, producer Step, over px.Value, variables []px.Parameter, into string) Iterator {
+	return &iterator{step{name, origin, when, parameters, returns}, style, producer, over, variables, into}
 }
 
 func (it *iterator) Label() string {

--- a/wf/reference.go
+++ b/wf/reference.go
@@ -1,6 +1,7 @@
 package wf
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
@@ -16,8 +17,8 @@ type reference struct {
 	referencedStep string
 }
 
-func MakeReference(name string, when Condition, input, output []px.Parameter, referencedStep string) Reference {
-	return &reference{step{name, when, input, output}, referencedStep}
+func MakeReference(name string, origin issue.Location, when Condition, input, output []px.Parameter, referencedStep string) Reference {
+	return &reference{step{name, origin, when, input, output}, referencedStep}
 }
 
 func (s *reference) Label() string {

--- a/wf/resource.go
+++ b/wf/resource.go
@@ -1,6 +1,7 @@
 package wf
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
@@ -25,8 +26,8 @@ type resource struct {
 	extId string
 }
 
-func MakeResource(name string, when Condition, parameters, returns []px.Parameter, extId string, state State) Resource {
-	return &resource{step{name, when, parameters, returns}, state, extId}
+func MakeResource(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, extId string, state State) Resource {
+	return &resource{step{name, origin, when, parameters, returns}, state, extId}
 }
 
 func (r *resource) ExternalId() string {

--- a/wf/statehandler.go
+++ b/wf/statehandler.go
@@ -1,6 +1,7 @@
 package wf
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
@@ -15,8 +16,8 @@ type stateHandler struct {
 	api interface{}
 }
 
-func MakeStateHandler(name string, when Condition, parameters, returns []px.Parameter, api interface{}) StateHandler {
-	return &stateHandler{step{name, when, parameters, returns}, api}
+func MakeStateHandler(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, api interface{}) StateHandler {
+	return &stateHandler{step{name, origin, when, parameters, returns}, api}
 }
 
 func (a *stateHandler) Label() string {

--- a/wf/step.go
+++ b/wf/step.go
@@ -10,6 +10,8 @@ import (
 type Step interface {
 	issue.Labeled
 
+	Origin() issue.Location
+
 	// When returns an optional Condition that controls whether or not this step participates
 	// in the workflow.
 	When() Condition
@@ -26,6 +28,7 @@ type Step interface {
 
 type step struct {
 	name       string
+	origin     issue.Location
 	when       Condition
 	parameters []px.Parameter
 	returns    []px.Parameter
@@ -37,6 +40,10 @@ func (a *step) When() Condition {
 
 func (a *step) Name() string {
 	return a.name
+}
+
+func (a *step) Origin() issue.Location {
+	return a.origin
 }
 
 func (a *step) Parameters() []px.Parameter {

--- a/wf/util.go
+++ b/wf/util.go
@@ -1,0 +1,19 @@
+package wf
+
+import (
+	"errors"
+	"fmt"
+)
+
+func ToError(r interface{}) error {
+	switch rx := r.(type) {
+	case error:
+		return rx
+	case fmt.Stringer:
+		return errors.New(rx.String())
+	case string:
+		return errors.New(rx)
+	default:
+		return fmt.Errorf("%+v", r)
+	}
+}

--- a/wf/workflow.go
+++ b/wf/workflow.go
@@ -1,6 +1,7 @@
 package wf
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
@@ -15,8 +16,8 @@ type workflow struct {
 	steps []Step
 }
 
-func MakeWorkflow(name string, when Condition, parameters, returns []px.Parameter, steps []Step) Workflow {
-	return &workflow{step{name, when, parameters, returns}, steps}
+func MakeWorkflow(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, steps []Step) Workflow {
+	return &workflow{step{name, origin, when, parameters, returns}, steps}
 }
 
 func (w *workflow) Label() string {


### PR DESCRIPTION
This commit improves how errors are propagated from the plug-in service
to the client and ensures that the location of all errors that
originates from a step evaluation or execution is included in the
error.

Relates to lyraproj/lyra#264