### PR TITLE
Use tailored Parameter with both alias and value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b
 	github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594
-	github.com/lyraproj/pcore v0.0.0-20190513110440-3136007d878d
+	github.com/lyraproj/pcore v0.0.0-20190514082225-61649d71c936
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594 h1:IcsHRQ3xzCIcK0eXpot8IYgEyUQPEFHmFErZwJcsDqk=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190513110440-3136007d878d h1:UGQ37YS1mhNm2I4xutG+DaM+4P4x/TEdWpQk950eWaI=
-github.com/lyraproj/pcore v0.0.0-20190513110440-3136007d878d/go.mod h1:NGvVSNVj6tF0acszsfqcu+qtNt5b1hlSiiL3oNSuNMI=
+github.com/lyraproj/pcore v0.0.0-20190514082225-61649d71c936 h1:oEI8jC1efmrpvMBe0ndLy9RVadxOwv8iYNV/FENemRA=
+github.com/lyraproj/pcore v0.0.0-20190514082225-61649d71c936/go.mod h1:NGvVSNVj6tF0acszsfqcu+qtNt5b1hlSiiL3oNSuNMI=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/grpc/hclogger.go
+++ b/grpc/hclogger.go
@@ -1,0 +1,57 @@
+package grpc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/lyraproj/issue/issue"
+	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/pcore/utils"
+)
+
+type hclogLogger struct {
+	log hclog.Logger
+}
+
+func NewHclogLogger(log hclog.Logger) px.Logger {
+	return &hclogLogger{log}
+}
+
+func (l *hclogLogger) Log(level px.LogLevel, args ...px.Value) {
+	w := bytes.NewBufferString(``)
+	for _, arg := range args {
+		px.ToString3(arg, w)
+	}
+	l.hcLog(level, w.String())
+}
+
+func (l *hclogLogger) Logf(level px.LogLevel, format string, args ...interface{}) {
+	l.hcLog(level, format, args...)
+}
+
+func (l *hclogLogger) hcLog(level px.LogLevel, format string, args ...interface{}) {
+	switch level {
+	case px.ERR, px.ALERT, px.CRIT, px.EMERG:
+		if l.log.IsError() {
+			l.log.Error(fmt.Sprintf(format, args...))
+		}
+	case px.WARNING:
+		if l.log.IsWarn() {
+			l.log.Warn(fmt.Sprintf(format, args...))
+		}
+	case px.INFO, px.NOTICE:
+		if l.log.IsInfo() {
+			l.log.Info(fmt.Sprintf(format, args...))
+		}
+	case px.DEBUG:
+		if l.log.IsDebug() {
+			l.log.Debug(fmt.Sprintf(format, args...))
+		}
+	}
+}
+
+func (l *hclogLogger) LogIssue(issue issue.Reported) {
+	utils.Fprintln(os.Stderr, issue.String())
+}

--- a/lang/go/lyra/action.go
+++ b/lang/go/lyra/action.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/lyraproj/servicesdk/serviceapi"
+
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
@@ -33,7 +35,7 @@ func (a *Action) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
 		panic(px.Error(NotActionFunction, issue.H{`name`: n, `type`: ft.String()}))
 	}
 
-	var parameters, returns []px.Parameter
+	var parameters, returns []serviceapi.Parameter
 	inc := ft.NumIn()
 	if ft.IsVariadic() || inc > 1 {
 		panic(badFunction(n, ft))

--- a/lang/go/lyra/collect.go
+++ b/lang/go/lyra/collect.go
@@ -3,6 +3,8 @@ package lyra
 import (
 	"reflect"
 
+	"github.com/lyraproj/servicesdk/serviceapi"
+
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
@@ -102,16 +104,16 @@ func value(c px.Context, uv interface{}) px.Value {
 	return px.Wrap(c, uv)
 }
 
-func paramsFromString(n string) []px.Parameter {
-	return []px.Parameter{paramFromString(n)}
+func paramsFromString(n string) []serviceapi.Parameter {
+	return []serviceapi.Parameter{paramFromString(n)}
 }
 
-func asParams(c px.Context, ns interface{}) []px.Parameter {
+func asParams(c px.Context, ns interface{}) []serviceapi.Parameter {
 	switch ns := ns.(type) {
 	case string:
 		return paramsFromString(ns)
 	case []string:
-		ps := make([]px.Parameter, len(ns))
+		ps := make([]serviceapi.Parameter, len(ns))
 		for i, n := range ns {
 			ps[i] = paramFromString(n)
 		}
@@ -121,11 +123,11 @@ func asParams(c px.Context, ns interface{}) []px.Parameter {
 	}
 }
 
-func paramFromString(n string) px.Parameter {
-	return px.NewParameter(issue.FirstToLower(n), types.DefaultAnyType(), nil, false)
+func paramFromString(n string) serviceapi.Parameter {
+	return serviceapi.NewParameter(issue.FirstToLower(n), ``, types.DefaultAnyType(), nil)
 }
 
-func paramFromStruct(c px.Context, s reflect.Value) px.Parameter {
+func paramFromStruct(c px.Context, s reflect.Value) serviceapi.Parameter {
 	params := paramsFromStruct(c, s.Type(), nil)
 	if len(params) != 1 {
 		panic(px.Error(NotOneStructField, issue.H{`type`: s.Type().String()}))

--- a/lang/go/lyra/reference.go
+++ b/lang/go/lyra/reference.go
@@ -3,6 +3,8 @@ package lyra
 import (
 	"reflect"
 
+	"github.com/lyraproj/servicesdk/serviceapi"
+
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/servicesdk/wf"
@@ -30,7 +32,7 @@ type Reference struct {
 }
 
 func (r *Reference) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
-	var parameters, returns []px.Parameter
+	var parameters, returns []serviceapi.Parameter
 	if r.Parameters != nil {
 		parameters = paramsFromStruct(c, reflect.TypeOf(r.Parameters), issue.FirstToLower)
 	}

--- a/lang/go/lyra/resource.go
+++ b/lang/go/lyra/resource.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/lyraproj/servicesdk/serviceapi"
+
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
@@ -82,7 +84,7 @@ func (r *Resource) Resolve(c px.Context, n string, loc issue.Location) wf.Step {
 		panic(badFunction(n, ft))
 	}
 
-	var parameters, returns []px.Parameter
+	var parameters, returns []serviceapi.Parameter
 
 	// Create return parameters from the Returns struct
 	if r.Return != nil {

--- a/service/builder.go
+++ b/service/builder.go
@@ -283,7 +283,7 @@ func (ds *Builder) createStepDefinition(step wf.Step) serviceapi.Definition {
 	return serviceapi.NewDefinition(px.NewTypedName(px.NsDefinition, name), ds.serviceId, types.WrapHash(props))
 }
 
-func paramsAsList(params []px.Parameter) px.List {
+func paramsAsList(params []serviceapi.Parameter) px.List {
 	np := len(params)
 	if np == 0 {
 		return nil

--- a/service/parameter.go
+++ b/service/parameter.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"io"
+
+	"github.com/lyraproj/servicesdk/serviceapi"
+
+	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/pcore/types"
+)
+
+type parameter struct {
+	name  string
+	alias string
+	typ   px.Type
+	value px.Value
+}
+
+func init() {
+	serviceapi.NewParameter = newParameter
+}
+
+func newParameter(name, alias string, typ px.Type, value px.Value) serviceapi.Parameter {
+	if alias == name {
+		alias = ``
+	}
+	return &parameter{name, alias, typ, value}
+}
+
+func (p *parameter) Name() string {
+	return p.name
+}
+
+func (p *parameter) Alias() string {
+	return p.alias
+}
+
+func (p *parameter) Value() px.Value {
+	return p.value
+}
+
+func (p *parameter) Type() px.Type {
+	return p.typ
+}
+
+func (p *parameter) Get(key string) (value px.Value, ok bool) {
+	switch key {
+	case `name`:
+		return types.WrapString(p.name), true
+	case `alias`:
+		if p.alias == `` {
+			return px.Undef, true
+		}
+		return types.WrapString(p.alias), true
+	case `type`:
+		return p.typ, true
+	case `value`:
+		if p.value == nil {
+			return px.Undef, true
+		}
+		return p.Value(), true
+	case `has_value`:
+		return types.WrapBoolean(p.value != nil), true
+	}
+	return nil, false
+}
+
+func (p *parameter) InitHash() px.OrderedMap {
+	es := make([]*types.HashEntry, 0, 3)
+	es = append(es, types.WrapHashEntry2(`name`, types.WrapString(p.name)))
+	if p.alias != `` {
+		es = append(es, types.WrapHashEntry2(`alias`, types.WrapString(p.alias)))
+	}
+	es = append(es, types.WrapHashEntry2(`type`, p.typ))
+	if p.value != nil {
+		es = append(es, types.WrapHashEntry2(`value`, p.value))
+	}
+	return types.WrapHash(es)
+}
+
+var ParameterMetaType px.Type
+
+func (p *parameter) Equals(other interface{}, guard px.Guard) bool {
+	return p == other
+}
+
+func (p *parameter) String() string {
+	return px.ToString(p)
+}
+
+func (p *parameter) ToString(bld io.Writer, format px.FormatContext, g px.RDetect) {
+	types.ObjectToString(p, format, bld, g)
+}
+
+func (p *parameter) PType() px.Type {
+	return ParameterMetaType
+}
+
+func init() {
+	ParameterMetaType = px.NewObjectType(`Lyra::Parameter`, `{
+    attributes => {
+      'name' => String,
+      'type' => Type,
+      'alias' => Optional[String],
+      'value' => Optional[Variant[Deferred,Data]],
+      'has_value' => { type => Boolean, kind => derived }
+    }
+  }`, func(ctx px.Context, args []px.Value) px.Value {
+		n := args[0].String()
+		t := args[1].(px.Type)
+		a := ``
+		if len(args) > 2 {
+			a = args[2].String()
+		}
+		var v px.Value
+		if len(args) > 3 {
+			v = args[3]
+		}
+		return newParameter(n, a, t, v)
+	}, func(ctx px.Context, args []px.Value) px.Value {
+		h := args[0].(*types.Hash)
+		n := h.Get5(`name`, px.EmptyString).String()
+		t := h.Get5(`type`, types.DefaultDataType()).(px.Type)
+		a := ``
+		if x, ok := h.Get4(`alias`); ok {
+			a = x.String()
+		}
+		var v px.Value
+		if x, ok := h.Get4(`value`); ok {
+			v = x
+		}
+		return newParameter(n, a, t, v)
+	})
+}

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -186,10 +186,16 @@ func ExampleServer_Metadata_definitions() {
 				`X`: &lyra.Resource{
 					State: func(struct {
 						A string
-						B string
+						B string `lookup:"foo"`
 					}) *MyRes {
 						return &MyRes{Name: `Bob`, Phone: `12345`}
-					}}}}).Resolve(c, `My::Test`, issue.ParseLocation(`(file: /test/x.go)`)))
+					}},
+				`Y`: &lyra.Reference{
+					Parameters: struct {
+						P string `lookup:"foo" alias:"B"`
+					}{},
+					StepName: `z`,
+				}}}).Resolve(c, `My::Test`, issue.ParseLocation(`(file: /test/x.go)`)))
 
 		s := sb.Server()
 		_, defs := s.Metadata(c)
@@ -221,16 +227,45 @@ func ExampleServer_Metadata_definitions() {
 	//         ),
 	//         'properties' => {
 	//           'parameters' => [
-	//             Parameter(
+	//             Lyra::Parameter(
 	//               'name' => 'a',
 	//               'type' => String
 	//             ),
-	//             Parameter(
+	//             Lyra::Parameter(
 	//               'name' => 'b',
-	//               'type' => String
+	//               'type' => String,
+	//               'value' => Deferred(
+	//                 'name' => 'lookup',
+	//                 'arguments' => ['foo']
+	//               )
 	//             )],
 	//           'resourceType' => My::MyRes,
 	//           'style' => 'resource',
+	//           'origin' => '(file: /test/x.go)'
+	//         }
+	//       ),
+	//       Service::Definition(
+	//         'identifier' => TypedName(
+	//           'namespace' => 'definition',
+	//           'name' => 'My::Test::Y'
+	//         ),
+	//         'serviceId' => TypedName(
+	//           'namespace' => 'service',
+	//           'name' => 'My::Service'
+	//         ),
+	//         'properties' => {
+	//           'parameters' => [
+	//             Lyra::Parameter(
+	//               'name' => 'p',
+	//               'alias' => 'b',
+	//               'type' => String,
+	//               'value' => Deferred(
+	//                 'name' => 'lookup',
+	//                 'arguments' => ['foo']
+	//               )
+	//             )],
+	//           'reference' => 'z',
+	//           'style' => 'reference',
 	//           'origin' => '(file: /test/x.go)'
 	//         }
 	//       )],

--- a/serviceapi/parameter.go
+++ b/serviceapi/parameter.go
@@ -1,0 +1,24 @@
+package serviceapi
+
+import "github.com/lyraproj/pcore/px"
+
+type Parameter interface {
+	px.Value
+
+	// Name of the parameter
+	Name() string
+
+	// Alias to use inside the step that uses this parameter or the empty
+	// string if no alias exists.
+	Alias() string
+
+	// The Type of the parameter.
+	Type() px.Type
+
+	// The parameter value, or nil if parameter has no value. An Undef is
+	// considered a valid value.
+	Value() px.Value
+}
+
+// NewParameter creates a new parameter instance
+var NewParameter func(name, alias string, typ px.Type, value px.Value) Parameter

--- a/wf/action.go
+++ b/wf/action.go
@@ -2,7 +2,7 @@ package wf
 
 import (
 	"github.com/lyraproj/issue/issue"
-	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type Action interface {
@@ -16,7 +16,7 @@ type action struct {
 	function interface{}
 }
 
-func MakeAction(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, function interface{}) Action {
+func MakeAction(name string, origin issue.Location, when Condition, parameters, returns []serviceapi.Parameter, function interface{}) Action {
 	return &action{step{name, origin, when, parameters, returns}, function}
 }
 

--- a/wf/builder.go
+++ b/wf/builder.go
@@ -3,11 +3,13 @@ package wf
 import (
 	"strings"
 
+	"github.com/lyraproj/servicesdk/serviceapi"
+
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
-var noParams = make([]px.Parameter, 0)
+var noParams = make([]serviceapi.Parameter, 0)
 
 func LeafName(name string) string {
 	names := strings.Split(name, `::`)
@@ -19,12 +21,12 @@ type Builder interface {
 	Build() Step
 	Name(string)
 	When(string)
-	Parameters(...px.Parameter)
-	Returns(...px.Parameter)
+	Parameters(...serviceapi.Parameter)
+	Returns(...serviceapi.Parameter)
 	QualifyName(childName string) string
-	GetParameters() []px.Parameter
+	GetParameters() []serviceapi.Parameter
 	GetName() string
-	Parameter(name, typeName string) px.Parameter
+	Parameter(name, typeName string) serviceapi.Parameter
 }
 
 type ChildBuilder interface {
@@ -52,7 +54,7 @@ type IteratorBuilder interface {
 	ChildBuilder
 	Style(IterationStyle)
 	Over(px.Value)
-	Variables(...px.Parameter)
+	Variables(...serviceapi.Parameter)
 	Into(into string)
 }
 
@@ -118,8 +120,8 @@ type builder struct {
 	origin     issue.Location
 	name       string
 	when       Condition
-	parameters []px.Parameter
-	returns    []px.Parameter
+	parameters []serviceapi.Parameter
+	returns    []serviceapi.Parameter
 	parent     Builder
 }
 
@@ -145,11 +147,11 @@ func (b *builder) validate() {
 	}
 }
 
-func (b *builder) Parameter(name, typeName string) px.Parameter {
-	return px.NewParameter(name, b.ctx.ParseType(typeName), nil, false)
+func (b *builder) Parameter(name, typeName string) serviceapi.Parameter {
+	return serviceapi.NewParameter(name, ``, b.ctx.ParseType(typeName), nil)
 }
 
-func (b *builder) GetParameters() []px.Parameter {
+func (b *builder) GetParameters() []serviceapi.Parameter {
 	return b.parameters
 }
 
@@ -168,7 +170,7 @@ func (b *builder) GetName() string {
 	return b.name
 }
 
-func (b *builder) Parameters(parameters ...px.Parameter) {
+func (b *builder) Parameters(parameters ...serviceapi.Parameter) {
 	if len(b.parameters) == 0 {
 		b.parameters = parameters
 	} else {
@@ -176,7 +178,7 @@ func (b *builder) Parameters(parameters ...px.Parameter) {
 	}
 }
 
-func (b *builder) Returns(returns ...px.Parameter) {
+func (b *builder) Returns(returns ...serviceapi.Parameter) {
 	if len(b.returns) == 0 {
 		b.returns = returns
 	} else {
@@ -241,7 +243,7 @@ type iteratorBuilder struct {
 	childBuilder
 	style     IterationStyle
 	over      px.Value
-	variables []px.Parameter
+	variables []serviceapi.Parameter
 	into      string
 }
 
@@ -300,7 +302,7 @@ func (b *iteratorBuilder) Into(into string) {
 	b.into = into
 }
 
-func (b *iteratorBuilder) Variables(variables ...px.Parameter) {
+func (b *iteratorBuilder) Variables(variables ...serviceapi.Parameter) {
 	if len(b.variables) == 0 {
 		b.variables = variables
 	} else {

--- a/wf/crd.go
+++ b/wf/crd.go
@@ -32,3 +32,35 @@ type CRUD interface {
 	// amended version of that state. The error NotFound is returned when no state can be found.
 	Update(externalId string, state px.OrderedMap) (px.OrderedMap, error)
 }
+
+var DoType px.Type
+var CrdType px.Type
+var CrudType px.Type
+
+func init() {
+	DoType = px.NewObjectType(`Lyra::Do`, `{
+		attributes => {
+      name => String
+    },
+    functions => {
+      do => Callable[[RichData,1], RichData]
+    }
+  }`)
+
+	CrdType = px.NewObjectType(`Lyra::CRD`, `{
+		attributes => {
+      name => String
+    },
+    functions => {
+      create => Callable[[Object], Tuple[Object,String]],
+      read   => Callable[[String], Object],
+      delete => Callable[[String], Boolean]
+    }
+  }`)
+
+	CrudType = px.NewObjectType(`Lyra::CRUD`, `Lyra::CRD{
+    functions => {
+      update => Callable[[String, Object], Object]
+    }
+  }`)
+}

--- a/wf/iterator.go
+++ b/wf/iterator.go
@@ -3,6 +3,7 @@ package wf
 import (
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type IterationStyle int
@@ -56,7 +57,7 @@ type Iterator interface {
 	// Variables returns the variables that this iterator will produce for each iteration. These
 	// variables will be removed from the declared parameters set when the final requirements
 	// for the step are computed.
-	Variables() []px.Parameter
+	Variables() []serviceapi.Parameter
 
 	// Into names the returns from the iteration
 	Into() string
@@ -67,12 +68,12 @@ type iterator struct {
 	style     IterationStyle
 	producer  Step
 	over      px.Value
-	variables []px.Parameter
+	variables []serviceapi.Parameter
 	into      string
 }
 
-func MakeIterator(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter,
-	style IterationStyle, producer Step, over px.Value, variables []px.Parameter, into string) Iterator {
+func MakeIterator(name string, origin issue.Location, when Condition, parameters, returns []serviceapi.Parameter,
+	style IterationStyle, producer Step, over px.Value, variables []serviceapi.Parameter, into string) Iterator {
 	return &iterator{step{name, origin, when, parameters, returns}, style, producer, over, variables, into}
 }
 
@@ -96,6 +97,6 @@ func (it *iterator) Into() string {
 	return it.into
 }
 
-func (it *iterator) Variables() []px.Parameter {
+func (it *iterator) Variables() []serviceapi.Parameter {
 	return it.variables
 }

--- a/wf/reference.go
+++ b/wf/reference.go
@@ -2,7 +2,7 @@ package wf
 
 import (
 	"github.com/lyraproj/issue/issue"
-	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type Reference interface {
@@ -17,7 +17,7 @@ type reference struct {
 	referencedStep string
 }
 
-func MakeReference(name string, origin issue.Location, when Condition, input, output []px.Parameter, referencedStep string) Reference {
+func MakeReference(name string, origin issue.Location, when Condition, input, output []serviceapi.Parameter, referencedStep string) Reference {
 	return &reference{step{name, origin, when, input, output}, referencedStep}
 }
 

--- a/wf/resource.go
+++ b/wf/resource.go
@@ -3,6 +3,7 @@ package wf
 import (
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type State interface {
@@ -26,7 +27,7 @@ type resource struct {
 	extId string
 }
 
-func MakeResource(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, extId string, state State) Resource {
+func MakeResource(name string, origin issue.Location, when Condition, parameters, returns []serviceapi.Parameter, extId string, state State) Resource {
 	return &resource{step{name, origin, when, parameters, returns}, state, extId}
 }
 

--- a/wf/statehandler.go
+++ b/wf/statehandler.go
@@ -2,7 +2,7 @@ package wf
 
 import (
 	"github.com/lyraproj/issue/issue"
-	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type StateHandler interface {
@@ -16,7 +16,7 @@ type stateHandler struct {
 	api interface{}
 }
 
-func MakeStateHandler(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, api interface{}) StateHandler {
+func MakeStateHandler(name string, origin issue.Location, when Condition, parameters, returns []serviceapi.Parameter, api interface{}) StateHandler {
 	return &stateHandler{step{name, origin, when, parameters, returns}, api}
 }
 

--- a/wf/step.go
+++ b/wf/step.go
@@ -3,6 +3,7 @@ package wf
 import (
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 // An Step of a Workflow. The workflow is an Step in itself and can be used in
@@ -20,18 +21,18 @@ type Step interface {
 	Name() string
 
 	// Parameters returns the parameters requirements for the Step
-	Parameters() []px.Parameter
+	Parameters() []serviceapi.Parameter
 
 	// Returns returns the definition of that this Step will produce
-	Returns() []px.Parameter
+	Returns() []serviceapi.Parameter
 }
 
 type step struct {
 	name       string
 	origin     issue.Location
 	when       Condition
-	parameters []px.Parameter
-	returns    []px.Parameter
+	parameters []serviceapi.Parameter
+	returns    []serviceapi.Parameter
 }
 
 func (a *step) When() Condition {
@@ -46,11 +47,11 @@ func (a *step) Origin() issue.Location {
 	return a.origin
 }
 
-func (a *step) Parameters() []px.Parameter {
+func (a *step) Parameters() []serviceapi.Parameter {
 	return a.parameters
 }
 
-func (a *step) Returns() []px.Parameter {
+func (a *step) Returns() []serviceapi.Parameter {
 	return a.returns
 }
 

--- a/wf/workflow.go
+++ b/wf/workflow.go
@@ -2,7 +2,7 @@ package wf
 
 import (
 	"github.com/lyraproj/issue/issue"
-	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type Workflow interface {
@@ -16,7 +16,7 @@ type workflow struct {
 	steps []Step
 }
 
-func MakeWorkflow(name string, origin issue.Location, when Condition, parameters, returns []px.Parameter, steps []Step) Workflow {
+func MakeWorkflow(name string, origin issue.Location, when Condition, parameters, returns []serviceapi.Parameter, steps []Step) Workflow {
 	return &workflow{step{name, origin, when, parameters, returns}, steps}
 }
 


### PR DESCRIPTION
Prior to this commit, Lyra used the px.Parameter for its parameters
and returns. This no longer worked when the "reference" type was
introduced, since it's sometimes desirable to have both an alias and
a value on the same parameter (value was used for both previously).
