### PR TITLE
Fix bugs when transforming Go struct into parameters

### DIFF
--- a/service/server_test.go
+++ b/service/server_test.go
@@ -186,7 +186,11 @@ func ExampleServer_Metadata_definitions() {
 				`X`: &lyra.Resource{
 					State: func(struct {
 						A string
-						B string `lookup:"foo"`
+						B string  `lookup:"foo"`
+						C int     `puppet:"value=>23"`
+						D *string `puppet:"value=>undef"`
+						E *string
+						F *string `value:"77"`
 					}) *MyRes {
 						return &MyRes{Name: `Bob`, Phone: `12345`}
 					}},
@@ -238,6 +242,25 @@ func ExampleServer_Metadata_definitions() {
 	//                 'name' => 'lookup',
 	//                 'arguments' => ['foo']
 	//               )
+	//             ),
+	//             Lyra::Parameter(
+	//               'name' => 'c',
+	//               'type' => Integer,
+	//               'value' => 23
+	//             ),
+	//             Lyra::Parameter(
+	//               'name' => 'd',
+	//               'type' => Optional[String],
+	//               'value' => undef
+	//             ),
+	//             Lyra::Parameter(
+	//               'name' => 'e',
+	//               'type' => Optional[String]
+	//             ),
+	//             Lyra::Parameter(
+	//               'name' => 'f',
+	//               'type' => Optional[String],
+	//               'value' => '77'
 	//             )],
 	//           'resourceType' => My::MyRes,
 	//           'style' => 'resource',


### PR DESCRIPTION
This commit fix a couple of errors in the logic that transforms a Go
structs into Step parameters and returns.

1. A variable was declared outside the loop over the fields which gave
   different behavior depending on parameter ordering. The 'value' for a
   parameter was not cleared between iterations.
2. An optional parameter was automatically declared to have a 'value' of
   undef. This was wrong. The 'value' of a parameter (although it can be
   allowed to be undef) must always be explicitly declared. In a Go
   struct, this means explicitly declaring it using a field annotation.