### PR TITLE
Ensure correct serialization of error arguments to issue.Reported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b
 	github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594
-	github.com/lyraproj/pcore v0.0.0-20190516164225-2c1838ece043
+	github.com/lyraproj/pcore v0.0.0-20190521101211-2b39bcf82658
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594 h1:IcsHRQ3xzCIcK0eXpot8IYgEyUQPEFHmFErZwJcsDqk=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190516164225-2c1838ece043 h1:tSLm3r+Z+ej4kyaXn7/okyw8sHkjE5LKZ1dNqA1gpVM=
-github.com/lyraproj/pcore v0.0.0-20190516164225-2c1838ece043/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
+github.com/lyraproj/pcore v0.0.0-20190521101211-2b39bcf82658 h1:t0Uf09WOnTYJ35RIO/R/D/qubjpVLr7BAa9qGAoP2ls=
+github.com/lyraproj/pcore v0.0.0-20190521101211-2b39bcf82658/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/service/error.go
+++ b/service/error.go
@@ -91,7 +91,14 @@ func errorFromReported(c px.Context, err issue.Reported) serviceapi.ErrorObject 
 	if len(keys) > 0 {
 		args := make([]*types.HashEntry, len(keys))
 		for i, k := range keys {
-			args[i] = types.WrapHashEntry2(k, px.Wrap(c, err.Argument(k)))
+			av := err.Argument(k)
+			var arg px.Value
+			if ea, ok := av.(error); ok {
+				arg = types.WrapString(ea.Error())
+			} else {
+				arg = px.Wrap(c, av)
+			}
+			args[i] = types.WrapHashEntry2(k, arg)
 		}
 		ds = append(ds, types.WrapHashEntry2(`arguments`, types.WrapHash(args)))
 	}


### PR DESCRIPTION
If an argument to an issue.Reported is of type `error` it must be
converted to a string using the Error() method before being serialized
to a stream because there's no way of knowing what the underlying
go type might be or how it will be serialized.

This commit ensures that the string conversion takes place before the
argument is stored in the ErrorObject that is used when the error
is serialized/deserialized.

Closes lyraproj/lyra#292