### PR TITLE
Improve error reporting of errors propagated over grpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ require (
 	github.com/hashicorp/go-hclog v0.8.0
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b
-	github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594
-	github.com/lyraproj/pcore v0.0.0-20190604153946-03f706b24291
+	github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15
+	github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,10 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQVnT5qjIKV4MB0j6RkRBVSZvhuD35vsnvglI=
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
-github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594 h1:IcsHRQ3xzCIcK0eXpot8IYgEyUQPEFHmFErZwJcsDqk=
-github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190604153946-03f706b24291 h1:XrveF2dlFKU7Ngi0rF1kyHPGRAyMZDerAl9y9peA0ps=
-github.com/lyraproj/pcore v0.0.0-20190604153946-03f706b24291/go.mod h1:ZnU8IagnqPnmjQDz2DiQaQvkKZVYpdePETJpOY8BAo0=
+github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15 h1:e1uefKgfSdC7uaYG9ipIZcpY+2gyefCYXQwsrWSdJLw=
+github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
+github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201 h1:KlTHcsEPuRXi/cXY2OuK6tPUiGmO2HzgqAbd4UF7niA=
+github.com/lyraproj/pcore v0.0.0-20190606102217-7824aee25201/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/grpc/issues.go
+++ b/grpc/issues.go
@@ -3,9 +3,13 @@ package grpc
 import "github.com/lyraproj/issue/issue"
 
 const (
-	InvocationError = `WF_INVOCATION_ERROR`
+	InvocationError       = `WF_INVOCATION_ERROR`
+	ProcInvocationError   = `WF_PROC_INVOCATION_ERROR`
+	RemoteInvocationError = `WF_REMOTE_INVOCATION_ERROR`
 )
 
 func init() {
-	issue.Hard(InvocationError, `invocation of %{identifier} %{name} failed: %{message}`)
+	issue.Hard(RemoteInvocationError, `Failed to invoke method %{executable}#%{identifier}/%{name}() on host %{host}`)
+	issue.Hard(ProcInvocationError, `Failed to invoke method %{executable}#%{identifier}/%{name}()`)
+	issue.Hard(InvocationError, `Failed to invoke method %{identifier}/%{name}()`)
 }

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -52,7 +52,7 @@ func (s *Server) Do(doer func(c px.Context)) (publicErr *datapb.Data, err error)
 					publicErr = ToDataPB(c, serviceapi.ErrorFromReported(c, e))
 				}
 			} else {
-				err = fmt.Errorf(`%+v`, e)
+				err = fmt.Errorf(`%v`, e)
 			}
 		}
 	}()

--- a/lang/go/lyra/action.go
+++ b/lang/go/lyra/action.go
@@ -181,7 +181,7 @@ func (a *goAction) amendError() {
 	if r := recover(); r != nil {
 		if rx, ok := r.(issue.Reported); ok {
 			// Location and stack included in nested error
-			r = issue.ErrorWithoutStack(wf.ActionExecutionError, issue.H{`step`: a.action.Label()}, nil, rx)
+			r = issue.ErrorWithStack(wf.ActionExecutionError, issue.H{`step`: a.action.Label()}, nil, rx, ``)
 		} else {
 			r = issue.NewNested(wf.ActionExecutionError, issue.H{`step`: a.action.Label()}, a.action.Origin(), wf.ToError(r))
 		}

--- a/lang/go/lyra/stateconverter.go
+++ b/lang/go/lyra/stateconverter.go
@@ -65,7 +65,7 @@ func (a *goState) amendError() {
 	if r := recover(); r != nil {
 		if rx, ok := r.(issue.Reported); ok {
 			// Location and stack included in nested error
-			r = issue.ErrorWithoutStack(wf.StateCreationError, issue.H{`step`: a.resource.Label()}, nil, rx)
+			r = issue.ErrorWithStack(wf.StateCreationError, issue.H{`step`: a.resource.Label()}, nil, rx, ``)
 		} else {
 			r = issue.NewNested(wf.StateCreationError, issue.H{`step`: a.resource.Label()}, a.resource.Origin(), wf.ToError(r))
 		}

--- a/service/parameter.go
+++ b/service/parameter.go
@@ -3,10 +3,9 @@ package service
 import (
 	"io"
 
-	"github.com/lyraproj/servicesdk/serviceapi"
-
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
+	"github.com/lyraproj/servicesdk/serviceapi"
 )
 
 type parameter struct {
@@ -23,6 +22,9 @@ func init() {
 func newParameter(name, alias string, typ px.Type, value px.Value) serviceapi.Parameter {
 	if alias == name {
 		alias = ``
+	}
+	if typ == nil {
+		typ = types.DefaultRichDataType()
 	}
 	return &parameter{name, alias, typ, value}
 }


### PR DESCRIPTION
This commit ensures that errors that are propagated over grpc contains
information about host, executable, and optionally stack (depends on if
debug logging is active or not). Errors are then reported with this
information unless the caller's information is the same (i.e. host
is not reported unless call is to another host).
