### PR TITLE
Add a default Resource annotation to simplify comparison logic

### DIFF
--- a/annotation/resource.go
+++ b/annotation/resource.go
@@ -79,6 +79,10 @@ type resource struct {
 	relationships       map[string]*Relationship
 }
 
+func DefaultResource() Resource {
+	return &resource{}
+}
+
 func NewResource(ctx px.Context, immutableAttributes, providedAttributes px.Value, relationships px.Value) Resource {
 	r := &resource{}
 


### PR DESCRIPTION
This commit adds a default Resource annotation that can be used by the
workflow engine when no annotation is found. This has the advantage of
always executing the same comparison logic with debug traces etc.