### PR TITLE
Propagate Lyra executable directory to plugin loader

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b
 	github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15
-	github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac
+	github.com/lyraproj/pcore v0.0.0-20190618142417-30605b6ee043
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15 h1:e1uefKgfSdC7uaYG9ipIZcpY+2gyefCYXQwsrWSdJLw=
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac h1:K4cTDfI72xRV+i7yOrZPyQqDFqbRq6smzgkxWUaSzv0=
-github.com/lyraproj/pcore v0.0.0-20190614121034-381c91502dac/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190618142417-30605b6ee043 h1:DPsZvbXM3NfCeJmE7IPz65jJJ2jrSTGkcmrfLNpfP0E=
+github.com/lyraproj/pcore v0.0.0-20190618142417-30605b6ee043/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
@@ -157,6 +158,9 @@ func Load(cmd *exec.Cmd, logger hclog.Logger) (serviceapi.Service, error) {
 		level = "error"
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("LYRA_LOG_LEVEL=%s", level))
+	if exe, err := os.Executable(); err == nil {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("LYRA_EXEDIR=%s", filepath.Dir(exe)))
+	}
 
 	client := plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: handshake,

--- a/service/loader.go
+++ b/service/loader.go
@@ -24,6 +24,14 @@ func init() {
 	// - WORKING_DIR/workflows
 	// - EXECUTABLE_DIR/../workflows (to support brew and running build\lyra irrespective of working dir)
 	defaultWorkflowsPath = []string{".", executableParentDir}
+
+	lyraExeDir := os.Getenv(`LYRA_EXEDIR`)
+	if lyraExeDir != `` {
+		lyraExeDir = filepath.Dir(lyraExeDir)
+		if lyraExeDir != executableParentDir {
+			defaultWorkflowsPath = append(defaultWorkflowsPath, lyraExeDir)
+		}
+	}
 }
 
 // New creates a new federated loader instance


### PR DESCRIPTION
This commit ensures that the environment variable LYRA_EXEDIR is set to
the directory of the lyra executable and that the federated loader used
in a plugin searches the parent of that directory for workflows and
types.