### PR TITLE
Use new ObjectType.InstanceHash() function from pcore

### DIFF
--- a/annotation/resource.go
+++ b/annotation/resource.go
@@ -286,17 +286,7 @@ func (r *resource) Get(key string) (value px.Value, ok bool) {
 }
 
 func (r *resource) InitHash() px.OrderedMap {
-	es := make([]*types.HashEntry, 3)
-	if r.immutableAttributes != nil {
-		es = append(es, types.WrapHashEntry2(`immutableAttributes`, r.ImmutableAttributesList()))
-	}
-	if r.providedAttributes != nil {
-		es = append(es, types.WrapHashEntry2(`providedAttributes`, r.ProvidedAttributesList()))
-	}
-	if r.relationships != nil {
-		es = append(es, types.WrapHashEntry2(`relationships`, r.RelationshipsMap()))
-	}
-	return types.WrapHash(es)
+	return ResourceType.InstanceHash(r)
 }
 
 func assertAttribute(ot px.ObjectType, n string) (a px.Attribute) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-plugin v0.0.0-20190220160451-3f118e8ee104
 	github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b
 	github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15
-	github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad
+	github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15 h1:e1uefKgfSdC7uaYG
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
 github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad h1:Smdt4D4MrveCvMVgQVQ7JAvMiY0+q5p/Nc/PKtQUv+E=
 github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58 h1:KVwA8JT513CGkM6SVLxGIfqeLUgW3p+dDq1UEC7lYG8=
+github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=

--- a/service/definition.go
+++ b/service/definition.go
@@ -64,11 +64,7 @@ func (d *definition) Get(key string) (value px.Value, ok bool) {
 }
 
 func (d *definition) InitHash() px.OrderedMap {
-	es := make([]*types.HashEntry, 0, 3)
-	es = append(es, types.WrapHashEntry2(`identifier`, d.identifier))
-	es = append(es, types.WrapHashEntry2(`serviceId`, d.serviceId))
-	es = append(es, types.WrapHashEntry2(`properties`, d.properties))
-	return types.WrapHash(es)
+	return serviceapi.DefinitionMetaType.InstanceHash(d)
 }
 
 func (d *definition) Equals(other interface{}, g px.Guard) bool {

--- a/service/error.go
+++ b/service/error.go
@@ -25,7 +25,7 @@ func init() {
 	  	kind => { type => Optional[String[1]], value => undef },
 		  issue_code => { type => Optional[String[1]], value => undef },
 		  partial_result => { type => Data, value => undef },
-	  	details => { type => Optional[Hash[String[1],RichData]], value => undef },
+	  	details => { type => Optional[Hash[String[1],RichData]], value => {} },
 		}}`,
 		func(ctx px.Context, args []px.Value) px.Value {
 			return newError2(ctx, args...)
@@ -251,6 +251,9 @@ func (e *errorObj) InitHash() px.OrderedMap {
 }
 
 func (e *errorObj) initType(c px.Context) {
+	if e.details == nil {
+		e.details = px.EmptyMap
+	}
 	if e.kind == `` && e.issueCode == `` {
 		e.typ = ErrorMetaType
 	} else {

--- a/service/error.go
+++ b/service/error.go
@@ -228,8 +228,14 @@ func (e *errorObj) Get(key string) (value px.Value, ok bool) {
 	case `message`:
 		return types.WrapString(e.message), true
 	case `kind`:
+		if e.kind == `` {
+			return px.Undef, true
+		}
 		return types.WrapString(e.kind), true
 	case `issue_code`:
+		if e.issueCode == `` {
+			return px.Undef, true
+		}
 		return types.WrapString(e.issueCode), true
 	case `partial_result`:
 		return e.partialResult, true
@@ -241,20 +247,7 @@ func (e *errorObj) Get(key string) (value px.Value, ok bool) {
 }
 
 func (e *errorObj) InitHash() px.OrderedMap {
-	entries := []*types.HashEntry{types.WrapHashEntry2(`message`, types.WrapString(e.message))}
-	if e.kind != `` {
-		entries = append(entries, types.WrapHashEntry2(`kind`, types.WrapString(e.kind)))
-	}
-	if e.issueCode != `` {
-		entries = append(entries, types.WrapHashEntry2(`issue_code`, types.WrapString(e.issueCode)))
-	}
-	if !e.partialResult.Equals(px.Undef, nil) {
-		entries = append(entries, types.WrapHashEntry2(`partial_result`, e.partialResult))
-	}
-	if !e.details.Equals(px.EmptyMap, nil) {
-		entries = append(entries, types.WrapHashEntry2(`details`, e.details))
-	}
-	return types.WrapHash(entries)
+	return ErrorMetaType.InstanceHash(e)
 }
 
 func (e *errorObj) initType(c px.Context) {

--- a/service/parameter.go
+++ b/service/parameter.go
@@ -68,19 +68,10 @@ func (p *parameter) Get(key string) (value px.Value, ok bool) {
 }
 
 func (p *parameter) InitHash() px.OrderedMap {
-	es := make([]*types.HashEntry, 0, 3)
-	es = append(es, types.WrapHashEntry2(`name`, types.WrapString(p.name)))
-	if p.alias != `` {
-		es = append(es, types.WrapHashEntry2(`alias`, types.WrapString(p.alias)))
-	}
-	es = append(es, types.WrapHashEntry2(`type`, p.typ))
-	if p.value != nil {
-		es = append(es, types.WrapHashEntry2(`value`, p.value))
-	}
-	return types.WrapHash(es)
+	return ParameterMetaType.InstanceHash(p)
 }
 
-var ParameterMetaType px.Type
+var ParameterMetaType px.ObjectType
 
 func (p *parameter) Equals(other interface{}, guard px.Guard) bool {
 	return p == other

--- a/service/server_test.go
+++ b/service/server_test.go
@@ -250,8 +250,7 @@ func ExampleServer_Metadata_definitions() {
 	//             ),
 	//             Lyra::Parameter(
 	//               'name' => 'd',
-	//               'type' => Optional[String],
-	//               'value' => undef
+	//               'type' => Optional[String]
 	//             ),
 	//             Lyra::Parameter(
 	//               'name' => 'e',
@@ -280,8 +279,8 @@ func ExampleServer_Metadata_definitions() {
 	//           'parameters' => [
 	//             Lyra::Parameter(
 	//               'name' => 'p',
-	//               'alias' => 'b',
 	//               'type' => String,
+	//               'alias' => 'b',
 	//               'value' => Deferred(
 	//                 'name' => 'lookup',
 	//                 'arguments' => ['foo']

--- a/serviceapi/definition.go
+++ b/serviceapi/definition.go
@@ -5,7 +5,7 @@ import (
 	"github.com/lyraproj/pcore/px"
 )
 
-var DefinitionMetaType px.Type
+var DefinitionMetaType px.ObjectType
 
 type Definition interface {
 	px.Value


### PR DESCRIPTION
Replace the body of all PuppetObject.InitHash() functions with a call
to the ObjectType.InitHash() function.